### PR TITLE
Add pyglet visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # platforms-in-planet
+
+A simple project demonstrating a simulator with planets, platforms, and a timekeeper.
+
+## Objects
+- `Planet` – represents a moving planet in space.
+- `Earth` – simple textured planet subclass.
+- `Platform` – a platform that can be attached to a planet.
+- `Time` – keeps track of simulation time.
+
+These are defined in the `objects` package.
+
+## Simulation
+
+`Simulation` groups a planet with a `Time` object and advances them together.
+
+## Visualization
+
+The `visualize` package contains a `Show` class which displays a simulation
+using pyglet 2.1. If the planet is an `Earth` instance and an image file named
+`earth.jpg` is present in the working directory, the texture will be mapped onto
+the sphere. Otherwise a solid blue planet is shown. Platforms are rendered as
+red spheres. Use the mouse to orbit around the planet and zoom with the scroll
+wheel.
+

--- a/objects/__init__.py
+++ b/objects/__init__.py
@@ -1,0 +1,8 @@
+"""Base objects for the platforms-in-planet simulator."""
+
+from .planet import Planet
+from .platform import Platform
+from .time import Time
+from .earth import Earth
+
+__all__ = ["Planet", "Platform", "Time", "Earth"]

--- a/objects/earth.py
+++ b/objects/earth.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+from .planet import Planet
+
+
+@dataclass
+class Earth(Planet):
+    """A simple Earth model referencing a texture image."""
+
+    texture_path: str = "earth.jpg"

--- a/objects/planet.py
+++ b/objects/planet.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+
+@dataclass
+class Planet:
+    """Represents a planet moving through space."""
+
+    name: str
+    position: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+    velocity: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+    platforms: List['Platform'] = field(default_factory=list)
+
+    def add_platform(self, platform: 'Platform') -> None:
+        """Attach a platform to this planet."""
+        self.platforms.append(platform)
+
+    def update(self, dt: float) -> None:
+        """Advance the planet and its platforms by ``dt`` seconds."""
+        x, y, z = self.position
+        vx, vy, vz = self.velocity
+        self.position = (x + vx * dt, y + vy * dt, z + vz * dt)
+        for platform in self.platforms:
+            platform.update(dt)

--- a/objects/platform.py
+++ b/objects/platform.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass
+class Platform:
+    """A movable platform attached to a planet."""
+
+    id: str
+    local_position: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+    velocity: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+
+    def update(self, dt: float) -> None:
+        """Move the platform relative to its current position."""
+        x, y, z = self.local_position
+        vx, vy, vz = self.velocity
+        self.local_position = (x + vx * dt, y + vy * dt, z + vz * dt)

--- a/objects/time.py
+++ b/objects/time.py
@@ -1,0 +1,9 @@
+class Time:
+    """Simple timekeeper for the simulation."""
+
+    def __init__(self, start_time: float = 0.0) -> None:
+        self.current_time = start_time
+
+    def advance(self, dt: float) -> None:
+        """Advance the clock by ``dt`` seconds."""
+        self.current_time += dt

--- a/simulation.py
+++ b/simulation.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass, field
+
+from objects import Planet, Time
+
+
+@dataclass
+class Simulation:
+    """Simple container for a planet and simulation time."""
+
+    planet: Planet
+    time: Time = field(default_factory=Time)
+
+    def update(self, dt: float) -> None:
+        """Advance the simulation by ``dt`` seconds."""
+        self.time.advance(dt)
+        self.planet.update(dt)

--- a/visualize/__init__.py
+++ b/visualize/__init__.py
@@ -1,0 +1,5 @@
+"""Visualization utilities for the simulator."""
+
+from .show import Show
+
+__all__ = ["Show"]

--- a/visualize/show.py
+++ b/visualize/show.py
@@ -1,0 +1,99 @@
+import math
+from typing import Optional
+
+import pyglet
+from pyglet import gl
+
+from simulation import Simulation
+from objects import Earth
+
+
+class Show(pyglet.window.Window):
+    """Display a simulation using pyglet 2.1."""
+
+    def __init__(self, simulation: Simulation, planet_radius: float = 1.0) -> None:
+        super().__init__(width=800, height=600, caption="Platform Visualization", resizable=True)
+        self.simulation = simulation
+        self.radius = planet_radius
+        self.azimuth = 45.0
+        self.elevation = 20.0
+        self.distance = self.radius * 2.5
+
+        pyglet.clock.schedule_interval(self._update, 1 / 60.0)
+
+        self.earth_texture: Optional[pyglet.image.Texture] = None
+        if isinstance(self.simulation.planet, Earth):
+            try:
+                image = pyglet.resource.image(self.simulation.planet.texture_path)
+                self.earth_texture = image.get_texture()
+            except Exception:
+                self.earth_texture = None
+
+        gl.glEnable(gl.GL_DEPTH_TEST)
+
+    # ---------------------------------------------------------
+    def _update(self, dt: float) -> None:
+        self.simulation.update(dt)
+
+    # ---------------------------------------------------------
+    def on_draw(self) -> None:
+        self.clear()
+        gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
+
+        gl.glMatrixMode(gl.GL_PROJECTION)
+        gl.glLoadIdentity()
+        aspect = self.width / float(self.height)
+        gl.gluPerspective(60.0, aspect, 0.1, 100.0)
+
+        gl.glMatrixMode(gl.GL_MODELVIEW)
+        gl.glLoadIdentity()
+
+        x = self.distance * math.cos(math.radians(self.elevation)) * math.sin(math.radians(self.azimuth))
+        y = self.distance * math.sin(math.radians(self.elevation))
+        z = self.distance * math.cos(math.radians(self.elevation)) * math.cos(math.radians(self.azimuth))
+        gl.gluLookAt(x, y, z, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0)
+
+        self._draw_planet()
+        self._draw_platforms()
+
+    # ---------------------------------------------------------
+    def _draw_planet(self) -> None:
+        if self.earth_texture:
+            gl.glEnable(gl.GL_TEXTURE_2D)
+            gl.glBindTexture(self.earth_texture.target, self.earth_texture.id)
+            quad = gl.gluNewQuadric()
+            gl.gluQuadricTexture(quad, True)
+            gl.gluQuadricNormals(quad, gl.GLU_SMOOTH)
+            gl.gluSphere(quad, self.radius, 36, 18)
+            gl.gluDeleteQuadric(quad)
+            gl.glDisable(gl.GL_TEXTURE_2D)
+        else:
+            gl.glColor3f(0.2, 0.2, 1.0)
+            quad = gl.gluNewQuadric()
+            gl.gluQuadricNormals(quad, gl.GLU_SMOOTH)
+            gl.gluSphere(quad, self.radius, 36, 18)
+            gl.gluDeleteQuadric(quad)
+
+    # ---------------------------------------------------------
+    def _draw_platforms(self) -> None:
+        for platform in self.simulation.planet.platforms:
+            x, y, z = platform.local_position
+            gl.glPushMatrix()
+            gl.glTranslatef(x, y, z)
+            gl.glColor3f(1.0, 0.0, 0.0)
+            quad = gl.gluNewQuadric()
+            gl.gluQuadricNormals(quad, gl.GLU_SMOOTH)
+            gl.gluSphere(quad, self.radius * 0.05, 16, 8)
+            gl.gluDeleteQuadric(quad)
+            gl.glPopMatrix()
+
+    # ---------------------------------------------------------
+    def on_mouse_drag(self, x: int, y: int, dx: int, dy: int, buttons: int, modifiers: int) -> None:
+        if buttons & pyglet.window.mouse.LEFT:
+            self.azimuth += dx * 0.3
+            self.elevation = max(-89.0, min(89.0, self.elevation + dy * 0.3))
+
+    # ---------------------------------------------------------
+    def on_mouse_scroll(self, x: int, y: int, scroll_x: int, scroll_y: int) -> None:
+        self.distance *= math.pow(1.1, -scroll_y)
+        self.distance = max(self.radius * 1.2, min(self.radius * 10.0, self.distance))


### PR DESCRIPTION
## Summary
- add an `Earth` subclass of `Planet`
- introduce a `Simulation` container
- implement `Show` window for pyglet-based visualization
- document new objects and viewer usage

## Testing
- `python -m py_compile objects/*.py visualize/*.py simulation.py`
