### PR TITLE
Add dual flight scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # platforms-in-planet
+
+A simple project demonstrating a simulator with planets, platforms, and a timekeeper.
+
+## Objects
+- `Planet` – represents a moving planet in space.
+- `Platform` – a platform that can be attached to a planet.
+- `Time` – keeps track of simulation time.
+- `Earth` – spherical Earth with helpers to convert latitude/longitude.
+- `Airplane` – platform that flies along a great-circle route.
+
+These are defined in the `objects` package.
+
+## Example
+
+The `examples` folder contains `dual_flight.py`, illustrating two airplanes
+flying simultaneously from Los Angeles to Philadelphia and from Atlanta to
+Los Angeles. The script compresses six hours of simulated flight into one real
+minute.
+
+Run it with:
+
+```bash
+python -m examples.dual_flight
+```

--- a/examples/dual_flight.py
+++ b/examples/dual_flight.py
@@ -1,0 +1,62 @@
+import time as realtime
+
+from objects import Earth, Airplane, Time
+from simulation import Simulation
+
+
+LAX = (33.9416, -118.4085)
+PHL = (39.8744, -75.2424)
+ATL = (33.6407, -84.4277)
+
+SIM_DURATION = 6 * 3600  # six hours
+REAL_DURATION = 60  # one minute
+STEPS = 120  # number of real-time steps
+
+
+def main() -> None:
+    earth = Earth(name="Earth")
+    clock = Time()
+
+    plane1 = Airplane(
+        id="LAX->PHL",
+        earth=earth,
+        start_lat=LAX[0],
+        start_lon=LAX[1],
+        end_lat=PHL[0],
+        end_lon=PHL[1],
+        duration=SIM_DURATION,
+        altitude=11000.0,
+    )
+
+    plane2 = Airplane(
+        id="ATL->LAX",
+        earth=earth,
+        start_lat=ATL[0],
+        start_lon=ATL[1],
+        end_lat=LAX[0],
+        end_lon=LAX[1],
+        duration=SIM_DURATION,
+        altitude=11000.0,
+    )
+
+    sim = Simulation(planet=earth, time=clock)
+    sim.add_platform(plane1)
+    sim.add_platform(plane2)
+
+    sim_dt = SIM_DURATION / STEPS
+    real_dt = REAL_DURATION / STEPS
+
+    for step in range(STEPS + 1):
+        sim.step(sim_dt)
+        if step % 10 == 0:
+            hours = clock.current_time / 3600
+            pos1 = plane1.local_position
+            pos2 = plane2.local_position
+            print(f"t={hours:.1f}h")
+            print(f"  {plane1.id} at {pos1}")
+            print(f"  {plane2.id} at {pos2}")
+        realtime.sleep(real_dt)
+
+
+if __name__ == "__main__":
+    main()

--- a/objects/__init__.py
+++ b/objects/__init__.py
@@ -1,0 +1,9 @@
+"""Base objects for the platforms-in-planet simulator."""
+
+from .planet import Planet
+from .platform import Platform
+from .time import Time
+from .earth import Earth
+from .airplane import Airplane
+
+__all__ = ["Planet", "Platform", "Time", "Earth", "Airplane"]

--- a/objects/airplane.py
+++ b/objects/airplane.py
@@ -1,0 +1,43 @@
+from typing import Tuple
+
+from .platform import Platform
+from .earth import Earth
+
+
+class Airplane(Platform):
+    """A simple airplane moving along a great-circle path."""
+
+    def __init__(
+        self,
+        id: str,
+        earth: Earth,
+        start_lat: float,
+        start_lon: float,
+        end_lat: float,
+        end_lon: float,
+        altitude: float = 10000.0,
+        duration: float = 21600.0,
+    ) -> None:
+        super().__init__(id)
+        self.earth = earth
+        self.start_lat = start_lat
+        self.start_lon = start_lon
+        self.end_lat = end_lat
+        self.end_lon = end_lon
+        self.altitude = altitude
+        self.duration = duration
+        self._elapsed = 0.0
+
+        self._start_unit = Earth.unit_from_latlon(start_lat, start_lon)
+        self._end_unit = Earth.unit_from_latlon(end_lat, end_lon)
+        angle = Earth.angle_between_units(self._start_unit, self._end_unit)
+        self.distance = earth.radius * angle
+        self.speed = self.distance / self.duration
+        self.local_position = earth.latlon_to_xyz(start_lat, start_lon, altitude)
+
+    def update(self, dt: float) -> None:
+        self._elapsed += dt
+        f = min(self._elapsed / self.duration, 1.0)
+        unit = Earth.slerp_unit(self._start_unit, self._end_unit, f)
+        r = self.earth.radius + self.altitude
+        self.local_position = (unit[0] * r, unit[1] * r, unit[2] * r)

--- a/objects/earth.py
+++ b/objects/earth.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass
+from typing import Tuple
+import math
+
+from .planet import Planet
+
+EARTH_RADIUS_M = 6371000.0
+
+
+def _latlon_to_unit(lat_deg: float, lon_deg: float) -> Tuple[float, float, float]:
+    lat = math.radians(lat_deg)
+    lon = math.radians(lon_deg)
+    x = math.cos(lat) * math.cos(lon)
+    y = math.cos(lat) * math.sin(lon)
+    z = math.sin(lat)
+    return (x, y, z)
+
+
+def _vector_angle(a: Tuple[float, float, float], b: Tuple[float, float, float]) -> float:
+    dot = a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+    dot = max(min(dot, 1.0), -1.0)
+    return math.acos(dot)
+
+
+def _slerp(a: Tuple[float, float, float], b: Tuple[float, float, float], f: float) -> Tuple[float, float, float]:
+    angle = _vector_angle(a, b)
+    if angle == 0.0:
+        return a
+    sin_total = math.sin(angle)
+    w1 = math.sin((1 - f) * angle) / sin_total
+    w2 = math.sin(f * angle) / sin_total
+    return (
+        w1 * a[0] + w2 * b[0],
+        w1 * a[1] + w2 * b[1],
+        w1 * a[2] + w2 * b[2],
+    )
+
+
+@dataclass
+class Earth(Planet):
+    """A simple spherical Earth model."""
+
+    radius: float = EARTH_RADIUS_M
+
+    def latlon_to_xyz(self, lat_deg: float, lon_deg: float, altitude_m: float = 0.0) -> Tuple[float, float, float]:
+        unit = _latlon_to_unit(lat_deg, lon_deg)
+        r = self.radius + altitude_m
+        return (unit[0] * r, unit[1] * r, unit[2] * r)
+
+    # Utility methods reused by Airplane
+    @staticmethod
+    def unit_from_latlon(lat_deg: float, lon_deg: float) -> Tuple[float, float, float]:
+        return _latlon_to_unit(lat_deg, lon_deg)
+
+    @staticmethod
+    def slerp_unit(a: Tuple[float, float, float], b: Tuple[float, float, float], f: float) -> Tuple[float, float, float]:
+        return _slerp(a, b, f)
+
+    @staticmethod
+    def angle_between_units(a: Tuple[float, float, float], b: Tuple[float, float, float]) -> float:
+        return _vector_angle(a, b)

--- a/objects/planet.py
+++ b/objects/planet.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+
+@dataclass
+class Planet:
+    """Represents a planet moving through space."""
+
+    name: str
+    position: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+    velocity: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+    platforms: List['Platform'] = field(default_factory=list)
+
+    def add_platform(self, platform: 'Platform') -> None:
+        """Attach a platform to this planet."""
+        self.platforms.append(platform)
+
+    def update(self, dt: float) -> None:
+        """Advance the planet and its platforms by ``dt`` seconds."""
+        x, y, z = self.position
+        vx, vy, vz = self.velocity
+        self.position = (x + vx * dt, y + vy * dt, z + vz * dt)
+        for platform in self.platforms:
+            platform.update(dt)

--- a/objects/platform.py
+++ b/objects/platform.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass
+class Platform:
+    """A movable platform attached to a planet."""
+
+    id: str
+    local_position: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+    velocity: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+
+    def update(self, dt: float) -> None:
+        """Move the platform relative to its current position."""
+        x, y, z = self.local_position
+        vx, vy, vz = self.velocity
+        self.local_position = (x + vx * dt, y + vy * dt, z + vz * dt)

--- a/objects/time.py
+++ b/objects/time.py
@@ -1,0 +1,9 @@
+class Time:
+    """Simple timekeeper for the simulation."""
+
+    def __init__(self, start_time: float = 0.0) -> None:
+        self.current_time = start_time
+
+    def advance(self, dt: float) -> None:
+        """Advance the clock by ``dt`` seconds."""
+        self.current_time += dt

--- a/simulation.py
+++ b/simulation.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, field
+from typing import List
+
+from objects.planet import Planet
+from objects.platform import Platform
+from objects.time import Time
+
+
+@dataclass
+class Simulation:
+    """Advance a planet and its platforms with a timekeeper."""
+
+    planet: Planet
+    time: Time
+    platforms: List[Platform] = field(default_factory=list)
+
+    def add_platform(self, platform: Platform) -> None:
+        self.platforms.append(platform)
+        self.planet.add_platform(platform)
+
+    def step(self, dt: float) -> None:
+        """Advance the simulation by ``dt`` seconds."""
+        self.planet.update(dt)
+        self.time.advance(dt)


### PR DESCRIPTION
## Summary
- add Earth class with lat/lon conversions
- implement Airplane moving on great-circle routes
- provide a Simulation helper class
- create `dual_flight.py` example showing two concurrent flights
- document new objects and example in README

## Testing
- `python -m py_compile objects/*.py simulation.py examples/dual_flight.py`
